### PR TITLE
Add robots.txt and sitemap for public pages

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://devdisplay.online/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://devdisplay.online/</loc>
+  </url>
+  <url>
+    <loc>https://devdisplay.online/board</loc>
+  </url>
+  <url>
+    <loc>https://devdisplay.online/trends</loc>
+  </url>
+  <url>
+    <loc>https://devdisplay.online/about</loc>
+  </url>
+  <url>
+    <loc>https://devdisplay.online/contact</loc>
+  </url>
+  <url>
+    <loc>https://devdisplay.online/art</loc>
+  </url>
+  <url>
+    <loc>https://devdisplay.online/PrivacyPolicy</loc>
+  </url>
+  <url>
+    <loc>https://devdisplay.online/privacyPolicyOrganizedNotes</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- allow all web crawlers and reference sitemap
- add sitemap.xml listing public routes

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3e19b7ad88327a091777e443331da

## Summary by Sourcery

Provide SEO support by adding a robots.txt file to allow all crawlers and reference the sitemap, and generate a sitemap.xml listing public page URLs for indexing

Enhancements:
- Add robots.txt to allow all web crawlers and point to the sitemap
- Add sitemap.xml enumerating all public routes for search engine indexing