### PR TITLE
Add react-helmet-async for page metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react": "^18.2.0",
         "react-bootstrap": "^2.9.1",
         "react-dom": "^18.2.0",
+        "react-helmet-async": "^2.0.5",
         "react-router": "^6.21.1",
         "react-router-bootstrap": "^0.26.2",
         "react-router-dom": "^6.21.1",
@@ -7753,6 +7754,26 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-helmet-async": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-2.0.5.tgz",
+      "integrity": "sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "react-fast-compare": "^3.2.2",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -8265,6 +8286,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react": "^18.2.0",
     "react-bootstrap": "^2.9.1",
     "react-dom": "^18.2.0",
+    "react-helmet-async": "^2.0.5",
     "react-router": "^6.21.1",
     "react-router-bootstrap": "^0.26.2",
     "react-router-dom": "^6.21.1",

--- a/src/components/pages/About.jsx
+++ b/src/components/pages/About.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Helmet } from "react-helmet-async";
 import "../../css/pages/About.css"; // Optional: Add a CSS file for styling
 import NavBar from "../modules/NavBar"; // Import NavBar component
 import animationVideo from "../../assets/animation/animation.mp4"; // Import the video file
@@ -11,6 +12,13 @@ import ScrollIndicator from "../modules/ScrollIndicator"; // Import ScrollIndica
 const About = () => {
   return (
     <>
+      <Helmet>
+        <title>About DevDisplay | Developer Showcase Overview</title>
+        <meta
+          name="description"
+          content="Explore DevDisplay's purpose, features, and the story behind this developer portfolio platform."
+        />
+      </Helmet>
       <NavBar />
       <div className="about-wrapper">
         <div className="about">

--- a/src/components/pages/Art.jsx
+++ b/src/components/pages/Art.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Helmet } from "react-helmet-async";
 import NavBar from "../modules/NavBar";
 import Footer from "../modules/Footer";
 import ScrollIndicator from "../modules/ScrollIndicator";
@@ -78,6 +79,13 @@ const Art = () => {
 
   return (
     <>
+      <Helmet>
+        <title>CAD Art Gallery | 3D Visualizations by Alex</title>
+        <meta
+          name="description"
+          content="Browse a curated collection of CAD art and 3D product visualizations crafted by developer Alex."
+        />
+      </Helmet>
       {/* Fixed background video */}
       <div className="page-bg">
         <video autoPlay loop muted playsInline className="video-bg">

--- a/src/components/pages/Board.jsx
+++ b/src/components/pages/Board.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { Helmet } from "react-helmet-async";
 import NavBar from "../modules/NavBar";
 import Footer from "../modules/Footer";
 import abstractbackground from "../../assets/153450-805374052_small-ezgif.com-reverse-video.mp4"; // Import the video file
@@ -143,6 +144,13 @@ const Board = () => {
   if (isLoading) {
     return (
       <>
+        <Helmet>
+          <title>Community Message Board | Share Your Thoughts on DevDisplay</title>
+          <meta
+            name="description"
+            content="Join the DevDisplay message board to post, view, and manage community messages in real time."
+          />
+        </Helmet>
         <NavBar />
         <div className="board-container">
           <div className="board-content">
@@ -160,8 +168,15 @@ const Board = () => {
 
   return (
     <>
-    <div className="board-wrapper">
-      <NavBar />
+      <Helmet>
+        <title>Community Message Board | Share Your Thoughts on DevDisplay</title>
+        <meta
+          name="description"
+          content="Join the DevDisplay message board to post, view, and manage community messages in real time."
+        />
+      </Helmet>
+      <div className="board-wrapper">
+        <NavBar />
       <div className="board-container">
         <div className="board-content">
           <video autoPlay loop muted playsInline className="video-bg">

--- a/src/components/pages/ChangePassword.jsx
+++ b/src/components/pages/ChangePassword.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Helmet } from "react-helmet-async";
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import apiFacade from "../../util/api/UserFacade";
@@ -47,6 +48,13 @@ const ChangePassword = () => {
 
   return (
     <>
+      <Helmet>
+        <title>Change Password | Secure Your DevDisplay Account</title>
+        <meta
+          name="description"
+          content="Update your DevDisplay login credentials to keep your account secure with a new password."
+        />
+      </Helmet>
       <NavBar />
       <div className="user-page-wrapper">
         <div className="user-page-container">

--- a/src/components/pages/Contact.jsx
+++ b/src/components/pages/Contact.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Helmet } from "react-helmet-async";
 import NavBar from "../modules/NavBar";
 import Footer from "../modules/Footer";
 import ScrollIndicator from "../modules/ScrollIndicator";
@@ -100,6 +101,13 @@ const ContactForm = () => {
 const Contact = () => {
   return (
     <>
+      <Helmet>
+        <title>Contact DevDisplay | Get in Touch with the Developer</title>
+        <meta
+          name="description"
+          content="Reach out to the DevDisplay creator via email or form to ask questions or share feedback."
+        />
+      </Helmet>
       <NavBar />
       <div className="contact-page-wrapper">
         <ContactForm />

--- a/src/components/pages/DeleteUser.jsx
+++ b/src/components/pages/DeleteUser.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { Helmet } from "react-helmet-async";
 import { useNavigate } from "react-router-dom";
 import apiFacade from "../../util/api/UserFacade";
 import NavBar from "../modules/NavBar";
@@ -45,6 +46,13 @@ const DeleteUser = () => {
 
   return (
     <>
+      <Helmet>
+        <title>Delete User Account | Remove Your DevDisplay Profile</title>
+        <meta
+          name="description"
+          content="Permanently delete your DevDisplay account and associated data with this confirmation form."
+        />
+      </Helmet>
       <NavBar />
       <div className="user-page-wrapper">
         <div className="user-page-container">

--- a/src/components/pages/Help.jsx
+++ b/src/components/pages/Help.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Helmet } from "react-helmet-async";
 import "../../css/pages/Help.css";
 import NavBar from "../modules/NavBar";
 import Footer from "../modules/Footer";
@@ -8,6 +9,13 @@ import ScrollIndicator from "../modules/ScrollIndicator"; // Import ScrollIndica
 function Help() {
   return (
     <>
+      <Helmet>
+        <title>DevDisplay Help Center | User Guide & Skraafoto Tips</title>
+        <meta
+          name="description"
+          content="Find step-by-step guidance for using DevDisplay, including image search, saving content, and Zone Kort integration."
+        />
+      </Helmet>
       <NavBar />
       <div className="help-wrapper">
         <div className="help">

--- a/src/components/pages/Images.jsx
+++ b/src/components/pages/Images.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { Helmet } from "react-helmet-async";
 import "../../css/pages/Images.css";
 import NavBar from "../modules/NavBar.jsx";
 import ImageFacade from "../../util/api/ImageFacade.js";
@@ -83,6 +84,13 @@ function Images() {
 
   return (
     <>
+      <Helmet>
+        <title>Image Search | Discover High-Resolution Photos</title>
+        <meta
+          name="description"
+          content="Search and explore high-quality images from Unsplash, save favorites, and view photographer details."
+        />
+      </Helmet>
       <NavBar />
       <div className="images-wrapper">
         <div className="images-container">

--- a/src/components/pages/NoMatch.jsx
+++ b/src/components/pages/NoMatch.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Helmet } from "react-helmet-async";
 import { Link } from "react-router-dom";
 import NavBar from "../modules/NavBar";
 import Footer from "../modules/Footer";
@@ -9,6 +10,13 @@ import ScrollIndicator from "../modules/ScrollIndicator";
 const NoMatch = () => {
   return (
     <>
+      <Helmet>
+        <title>404 - Page Not Found | DevDisplay Navigation Error</title>
+        <meta
+          name="description"
+          content="The page you requested could not be found. Use these links to return to popular sections of DevDisplay."
+        />
+      </Helmet>
       <NavBar />
       <div className="nomatch-wrapper">
         <div className="nomatch-container">

--- a/src/components/pages/Saved.jsx
+++ b/src/components/pages/Saved.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Helmet } from "react-helmet-async";
 import { useEffect, useState } from "react";
 import ImageFacade from "../../util/api/ImageFacade.js";
 import NavBar from "../modules/NavBar.jsx";
@@ -72,6 +73,13 @@ const SavedImages = () => {
 
   return (
     <>
+      <Helmet>
+        <title>Saved Images | Manage Your DevDisplay Collection</title>
+        <meta
+          name="description"
+          content="Review and organize images you've saved on DevDisplay, see user stats, and delete items easily."
+        />
+      </Helmet>
       <NavBar />
       {sessionStorage.getItem("isLoggedIn") === "true" ? (
         <div className="images-wrapper">

--- a/src/components/pages/Trends.jsx
+++ b/src/components/pages/Trends.jsx
@@ -1,5 +1,6 @@
 // YouTubeTrends.jsx
 import React from "react";
+import { Helmet } from "react-helmet-async";
 import { useState, useEffect } from "react";
 import axios from "axios";
 import {
@@ -75,6 +76,13 @@ export default function YouTubeTrends() {
 
   return (
     <>
+      <Helmet>
+        <title>YouTube Trends Analyzer | Track Popular Videos</title>
+        <meta
+          name="description"
+          content="Visualize trending YouTube videos by country and category with DevDisplay's interactive charts."
+        />
+      </Helmet>
       <div className="youtube-trends-bg">
         <NavBar />
         <div className="youtube-trends-wrapper">

--- a/src/components/pages/UserPage.jsx
+++ b/src/components/pages/UserPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { Helmet } from "react-helmet-async";
 import { useNavigate } from "react-router-dom";
 import "../../css/pages/UserPage.css";
 import NavBar from "../modules/NavBar";
@@ -63,6 +64,13 @@ const UserPage = () => {
 
   return (
     <>
+      <Helmet>
+        <title>User Dashboard | Manage Your DevDisplay Profile</title>
+        <meta
+          name="description"
+          content="View and update your DevDisplay user information, change password, or delete your account."
+        />
+      </Helmet>
       <NavBar />
       <div className="user-page-wrapper">
         <div className="user-page-container">

--- a/src/components/pages/Youtube.jsx
+++ b/src/components/pages/Youtube.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Helmet } from "react-helmet-async";
 import { useState, useEffect, useCallback } from "react";
 import "../../css/pages/Youtube.css";
 import NavBar from "../modules/NavBar";
@@ -58,6 +59,13 @@ function Youtube() {
 
   return (
     <>
+      <Helmet>
+        <title>YouTube Video Search | Discover Trending Clips</title>
+        <meta
+          name="description"
+          content="Search YouTube through DevDisplay to explore trending videos, load more results, and watch clips instantly."
+        />
+      </Helmet>
       <NavBar />
       <div className="youtube-wrapper">
         <div className="youtube-container">

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,11 +1,14 @@
 // filepath: c:\Projekter\Maskinen\src\main.jsx
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { HelmetProvider } from "react-helmet-async";
 import Root from "./Root.jsx"; // Import the Root component
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <Root />
+    <HelmetProvider>
+      <Root />
+    </HelmetProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- install `react-helmet-async` and wrap app with `HelmetProvider`
- add `<Helmet>` with page-specific titles and descriptions to all page components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c3e2e754b08327832e114857393d94

## Summary by Sourcery

Integrate react-helmet-async to manage page metadata and provide SEO-friendly titles and descriptions across the application

New Features:
- Install react-helmet-async and wrap the root application with HelmetProvider
- Add <Helmet> tags with page-specific <title> and meta description elements to all page components