### PR TITLE
Add Open Graph and Twitter metadata to page components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react": "^18.2.0",
         "react-bootstrap": "^2.9.1",
         "react-dom": "^18.2.0",
+        "react-helmet": "^6.1.0",
         "react-router": "^6.21.1",
         "react-router-bootstrap": "^0.26.2",
         "react-router-dom": "^6.21.1",
@@ -7753,6 +7754,27 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -7813,6 +7835,15 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-side-effect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
+      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-smooth": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react": "^18.2.0",
     "react-bootstrap": "^2.9.1",
     "react-dom": "^18.2.0",
+    "react-helmet": "^6.1.0",
     "react-router": "^6.21.1",
     "react-router-bootstrap": "^0.26.2",
     "react-router-dom": "^6.21.1",

--- a/src/components/pages/About.jsx
+++ b/src/components/pages/About.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Helmet } from "react-helmet";
 import "../../css/pages/About.css"; // Optional: Add a CSS file for styling
 import NavBar from "../modules/NavBar"; // Import NavBar component
 import animationVideo from "../../assets/animation/animation.mp4"; // Import the video file
@@ -11,6 +12,30 @@ import ScrollIndicator from "../modules/ScrollIndicator"; // Import ScrollIndica
 const About = () => {
   return (
     <>
+      <Helmet>
+        <title>About DevDisplay | Developer Showcase Overview</title>
+        <meta property="og:title" content="About DevDisplay | Developer Showcase Overview" />
+        <meta
+          property="og:description"
+          content="Learn about DevDisplay's mission and the developer behind the showcase."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://devdisplay.online/about" />
+        <meta
+          property="og:image"
+          content="https://images.unsplash.com/photo-1522199710521-72d69614c702?auto=format&fit=crop&w=1200&h=630&q=80"
+        />
+        <meta name="twitter:title" content="About DevDisplay | Developer Showcase Overview" />
+        <meta
+          name="twitter:description"
+          content="Learn about DevDisplay's mission and the developer behind the showcase."
+        />
+        <meta
+          name="twitter:image"
+          content="https://images.unsplash.com/photo-1522199710521-72d69614c702?auto=format&fit=crop&w=1200&h=630&q=80"
+        />
+        <meta name="twitter:card" content="summary_large_image" />
+      </Helmet>
       <NavBar />
       <div className="about-wrapper">
         <div className="about">

--- a/src/components/pages/Art.jsx
+++ b/src/components/pages/Art.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Helmet } from "react-helmet";
 import NavBar from "../modules/NavBar";
 import Footer from "../modules/Footer";
 import ScrollIndicator from "../modules/ScrollIndicator";
@@ -89,7 +90,30 @@ const Art = () => {
       {/* Foreground content */}
       <div className="site-root">
         <NavBar />
-
+        <Helmet>
+          <title>CAD Art Gallery | DevDisplay</title>
+          <meta property="og:title" content="CAD Art Gallery | DevDisplay" />
+          <meta
+            property="og:description"
+            content="View a curated gallery of CAD art and mechanical design renders."
+          />
+          <meta property="og:type" content="website" />
+          <meta property="og:url" content="https://devdisplay.online/art" />
+          <meta
+            property="og:image"
+            content="https://images.unsplash.com/photo-1534790566855-4cb788d389ec?auto=format&fit=crop&w=1200&h=630&q=80"
+          />
+          <meta name="twitter:title" content="CAD Art Gallery | DevDisplay" />
+          <meta
+            name="twitter:description"
+            content="View a curated gallery of CAD art and mechanical design renders."
+          />
+          <meta
+            name="twitter:image"
+            content="https://images.unsplash.com/photo-1534790566855-4cb788d389ec?auto=format&fit=crop&w=1200&h=630&q=80"
+          />
+          <meta name="twitter:card" content="summary_large_image" />
+        </Helmet>
         <main className="art-page-wrapper">
           <div className="art-container">
             <header className="art-header">

--- a/src/components/pages/Board.jsx
+++ b/src/components/pages/Board.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { Helmet } from "react-helmet";
 import NavBar from "../modules/NavBar";
 import Footer from "../modules/Footer";
 import abstractbackground from "../../assets/153450-805374052_small-ezgif.com-reverse-video.mp4"; // Import the video file
@@ -143,6 +144,36 @@ const Board = () => {
   if (isLoading) {
     return (
       <>
+        <Helmet>
+          <title>Community Message Board | DevDisplay</title>
+          <meta
+            property="og:title"
+            content="Community Message Board | DevDisplay"
+          />
+          <meta
+            property="og:description"
+            content="Share and view messages from the DevDisplay community."
+          />
+          <meta property="og:type" content="website" />
+          <meta property="og:url" content="https://devdisplay.online/board" />
+          <meta
+            property="og:image"
+            content="https://images.unsplash.com/photo-1492724441997-5dc865305da7?auto=format&fit=crop&w=1200&h=630&q=80"
+          />
+          <meta
+            name="twitter:title"
+            content="Community Message Board | DevDisplay"
+          />
+          <meta
+            name="twitter:description"
+            content="Share and view messages from the DevDisplay community."
+          />
+          <meta
+            name="twitter:image"
+            content="https://images.unsplash.com/photo-1492724441997-5dc865305da7?auto=format&fit=crop&w=1200&h=630&q=80"
+          />
+          <meta name="twitter:card" content="summary_large_image" />
+        </Helmet>
         <NavBar />
         <div className="board-container">
           <div className="board-content">
@@ -160,6 +191,30 @@ const Board = () => {
 
   return (
     <>
+      <Helmet>
+        <title>Community Message Board | DevDisplay</title>
+        <meta property="og:title" content="Community Message Board | DevDisplay" />
+        <meta
+          property="og:description"
+          content="Share and view messages from the DevDisplay community."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://devdisplay.online/board" />
+        <meta
+          property="og:image"
+          content="https://images.unsplash.com/photo-1492724441997-5dc865305da7?auto=format&fit=crop&w=1200&h=630&q=80"
+        />
+        <meta name="twitter:title" content="Community Message Board | DevDisplay" />
+        <meta
+          name="twitter:description"
+          content="Share and view messages from the DevDisplay community."
+        />
+        <meta
+          name="twitter:image"
+          content="https://images.unsplash.com/photo-1492724441997-5dc865305da7?auto=format&fit=crop&w=1200&h=630&q=80"
+        />
+        <meta name="twitter:card" content="summary_large_image" />
+      </Helmet>
     <div className="board-wrapper">
       <NavBar />
       <div className="board-container">

--- a/src/components/pages/ChangePassword.jsx
+++ b/src/components/pages/ChangePassword.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useState, useEffect } from "react";
+import { Helmet } from "react-helmet";
 import { useNavigate } from "react-router-dom";
 import apiFacade from "../../util/api/UserFacade";
 import NavBar from "../modules/NavBar";
@@ -47,6 +48,30 @@ const ChangePassword = () => {
 
   return (
     <>
+      <Helmet>
+        <title>Change Password | DevDisplay</title>
+        <meta property="og:title" content="Change Password | DevDisplay" />
+        <meta
+          property="og:description"
+          content="Update your DevDisplay account password securely."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://devdisplay.online/changepassword" />
+        <meta
+          property="og:image"
+          content="https://images.unsplash.com/photo-1607746882042-944635dfe10e?auto=format&fit=crop&w=1200&h=630&q=80"
+        />
+        <meta name="twitter:title" content="Change Password | DevDisplay" />
+        <meta
+          name="twitter:description"
+          content="Update your DevDisplay account password securely."
+        />
+        <meta
+          name="twitter:image"
+          content="https://images.unsplash.com/photo-1607746882042-944635dfe10e?auto=format&fit=crop&w=1200&h=630&q=80"
+        />
+        <meta name="twitter:card" content="summary_large_image" />
+      </Helmet>
       <NavBar />
       <div className="user-page-wrapper">
         <div className="user-page-container">

--- a/src/components/pages/Contact.jsx
+++ b/src/components/pages/Contact.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Helmet } from "react-helmet";
 import NavBar from "../modules/NavBar";
 import Footer from "../modules/Footer";
 import ScrollIndicator from "../modules/ScrollIndicator";
@@ -100,6 +101,30 @@ const ContactForm = () => {
 const Contact = () => {
   return (
     <>
+      <Helmet>
+        <title>Contact DevDisplay | Get in Touch</title>
+        <meta property="og:title" content="Contact DevDisplay | Get in Touch" />
+        <meta
+          property="og:description"
+          content="Reach out to DevDisplay with questions or feedback through the contact form."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://devdisplay.online/contact" />
+        <meta
+          property="og:image"
+          content="https://images.unsplash.com/photo-1581291519195-ef11498d1cf8?auto=format&fit=crop&w=1200&h=630&q=80"
+        />
+        <meta name="twitter:title" content="Contact DevDisplay | Get in Touch" />
+        <meta
+          name="twitter:description"
+          content="Reach out to DevDisplay with questions or feedback through the contact form."
+        />
+        <meta
+          name="twitter:image"
+          content="https://images.unsplash.com/photo-1581291519195-ef11498d1cf8?auto=format&fit=crop&w=1200&h=630&q=80"
+        />
+        <meta name="twitter:card" content="summary_large_image" />
+      </Helmet>
       <NavBar />
       <div className="contact-page-wrapper">
         <ContactForm />

--- a/src/components/pages/DeleteUser.jsx
+++ b/src/components/pages/DeleteUser.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import apiFacade from "../../util/api/UserFacade";
+import { Helmet } from "react-helmet";
 import NavBar from "../modules/NavBar";
 import Footer from "../modules/Footer";
 import { LinkContainer } from "react-router-bootstrap";
@@ -45,6 +46,30 @@ const DeleteUser = () => {
 
   return (
     <>
+      <Helmet>
+        <title>Delete Account | DevDisplay</title>
+        <meta property="og:title" content="Delete Account | DevDisplay" />
+        <meta
+          property="og:description"
+          content="Permanently remove your DevDisplay user account."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://devdisplay.online/deleteuser" />
+        <meta
+          property="og:image"
+          content="https://images.unsplash.com/photo-1521791136064-7986c2920216?auto=format&fit=crop&w=1200&h=630&q=80"
+        />
+        <meta name="twitter:title" content="Delete Account | DevDisplay" />
+        <meta
+          name="twitter:description"
+          content="Permanently remove your DevDisplay user account."
+        />
+        <meta
+          name="twitter:image"
+          content="https://images.unsplash.com/photo-1521791136064-7986c2920216?auto=format&fit=crop&w=1200&h=630&q=80"
+        />
+        <meta name="twitter:card" content="summary_large_image" />
+      </Helmet>
       <NavBar />
       <div className="user-page-wrapper">
         <div className="user-page-container">

--- a/src/components/pages/Help.jsx
+++ b/src/components/pages/Help.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Helmet } from "react-helmet";
 import "../../css/pages/Help.css";
 import NavBar from "../modules/NavBar";
 import Footer from "../modules/Footer";
@@ -8,6 +9,30 @@ import ScrollIndicator from "../modules/ScrollIndicator"; // Import ScrollIndica
 function Help() {
   return (
     <>
+      <Helmet>
+        <title>Help & User Guide | DevDisplay</title>
+        <meta property="og:title" content="Help & User Guide | DevDisplay" />
+        <meta
+          property="og:description"
+          content="Discover how to navigate DevDisplay and use its features effectively."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://devdisplay.online/help" />
+        <meta
+          property="og:image"
+          content="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&h=630&q=80"
+        />
+        <meta name="twitter:title" content="Help & User Guide | DevDisplay" />
+        <meta
+          name="twitter:description"
+          content="Discover how to navigate DevDisplay and use its features effectively."
+        />
+        <meta
+          name="twitter:image"
+          content="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&h=630&q=80"
+        />
+        <meta name="twitter:card" content="summary_large_image" />
+      </Helmet>
       <NavBar />
       <div className="help-wrapper">
         <div className="help">

--- a/src/components/pages/Images.jsx
+++ b/src/components/pages/Images.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { Helmet } from "react-helmet";
 import "../../css/pages/Images.css";
 import NavBar from "../modules/NavBar.jsx";
 import ImageFacade from "../../util/api/ImageFacade.js";
@@ -83,6 +84,30 @@ function Images() {
 
   return (
     <>
+      <Helmet>
+        <title>Image Search | DevDisplay</title>
+        <meta property="og:title" content="Image Search | DevDisplay" />
+        <meta
+          property="og:description"
+          content="Search high-quality images powered by Unsplash on DevDisplay."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://devdisplay.online/images" />
+        <meta
+          property="og:image"
+          content="https://images.unsplash.com/photo-1503023345310-bd7c1de61c7d?auto=format&fit=crop&w=1200&h=630&q=80"
+        />
+        <meta name="twitter:title" content="Image Search | DevDisplay" />
+        <meta
+          name="twitter:description"
+          content="Search high-quality images powered by Unsplash on DevDisplay."
+        />
+        <meta
+          name="twitter:image"
+          content="https://images.unsplash.com/photo-1503023345310-bd7c1de61c7d?auto=format&fit=crop&w=1200&h=630&q=80"
+        />
+        <meta name="twitter:card" content="summary_large_image" />
+      </Helmet>
       <NavBar />
       <div className="images-wrapper">
         <div className="images-container">

--- a/src/components/pages/NoMatch.jsx
+++ b/src/components/pages/NoMatch.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Helmet } from "react-helmet";
 import { Link } from "react-router-dom";
 import NavBar from "../modules/NavBar";
 import Footer from "../modules/Footer";
@@ -9,6 +10,30 @@ import ScrollIndicator from "../modules/ScrollIndicator";
 const NoMatch = () => {
   return (
     <>
+      <Helmet>
+        <title>Page Not Found | DevDisplay</title>
+        <meta property="og:title" content="Page Not Found | DevDisplay" />
+        <meta
+          property="og:description"
+          content="The page you're looking for doesn't exist. Find your way back to DevDisplay's main sections."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://devdisplay.online/404" />
+        <meta
+          property="og:image"
+          content="https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=1200&h=630&q=80"
+        />
+        <meta name="twitter:title" content="Page Not Found | DevDisplay" />
+        <meta
+          name="twitter:description"
+          content="The page you're looking for doesn't exist. Find your way back to DevDisplay's main sections."
+        />
+        <meta
+          name="twitter:image"
+          content="https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=1200&h=630&q=80"
+        />
+        <meta name="twitter:card" content="summary_large_image" />
+      </Helmet>
       <NavBar />
       <div className="nomatch-wrapper">
         <div className="nomatch-container">

--- a/src/components/pages/Saved.jsx
+++ b/src/components/pages/Saved.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useEffect, useState } from "react";
+import { Helmet } from "react-helmet";
 import ImageFacade from "../../util/api/ImageFacade.js";
 import NavBar from "../modules/NavBar.jsx";
 import "../../css/pages/Images.css";
@@ -72,6 +73,30 @@ const SavedImages = () => {
 
   return (
     <>
+      <Helmet>
+        <title>Saved Images | DevDisplay</title>
+        <meta property="og:title" content="Saved Images | DevDisplay" />
+        <meta
+          property="og:description"
+          content="View and manage images you've saved on DevDisplay."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://devdisplay.online/saved" />
+        <meta
+          property="og:image"
+          content="https://images.unsplash.com/photo-1517817748490-0bfa04a8a8a4?auto=format&fit=crop&w=1200&h=630&q=80"
+        />
+        <meta name="twitter:title" content="Saved Images | DevDisplay" />
+        <meta
+          name="twitter:description"
+          content="View and manage images you've saved on DevDisplay."
+        />
+        <meta
+          name="twitter:image"
+          content="https://images.unsplash.com/photo-1517817748490-0bfa04a8a8a4?auto=format&fit=crop&w=1200&h=630&q=80"
+        />
+        <meta name="twitter:card" content="summary_large_image" />
+      </Helmet>
       <NavBar />
       {sessionStorage.getItem("isLoggedIn") === "true" ? (
         <div className="images-wrapper">

--- a/src/components/pages/Trends.jsx
+++ b/src/components/pages/Trends.jsx
@@ -1,6 +1,7 @@
 // YouTubeTrends.jsx
 import React from "react";
 import { useState, useEffect } from "react";
+import { Helmet } from "react-helmet";
 import axios from "axios";
 import {
   LineChart,
@@ -75,6 +76,30 @@ export default function YouTubeTrends() {
 
   return (
     <>
+      <Helmet>
+        <title>YouTube Trends Analyzer | DevDisplay</title>
+        <meta property="og:title" content="YouTube Trends Analyzer | DevDisplay" />
+        <meta
+          property="og:description"
+          content="Explore trending YouTube videos across categories and countries."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://devdisplay.online/trends" />
+        <meta
+          property="og:image"
+          content="https://images.unsplash.com/photo-1518779578993-ec3579fee39f?auto=format&fit=crop&w=1200&h=630&q=80"
+        />
+        <meta name="twitter:title" content="YouTube Trends Analyzer | DevDisplay" />
+        <meta
+          name="twitter:description"
+          content="Explore trending YouTube videos across categories and countries."
+        />
+        <meta
+          name="twitter:image"
+          content="https://images.unsplash.com/photo-1518779578993-ec3579fee39f?auto=format&fit=crop&w=1200&h=630&q=80"
+        />
+        <meta name="twitter:card" content="summary_large_image" />
+      </Helmet>
       <div className="youtube-trends-bg">
         <NavBar />
         <div className="youtube-trends-wrapper">

--- a/src/components/pages/UserPage.jsx
+++ b/src/components/pages/UserPage.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import { Helmet } from "react-helmet";
 import "../../css/pages/UserPage.css";
 import NavBar from "../modules/NavBar";
 import apiFacade from "../../util/api/UserFacade";
@@ -63,6 +64,30 @@ const UserPage = () => {
 
   return (
     <>
+      <Helmet>
+        <title>User Dashboard | DevDisplay</title>
+        <meta property="og:title" content="User Dashboard | DevDisplay" />
+        <meta
+          property="og:description"
+          content="Manage your DevDisplay profile and account settings."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://devdisplay.online/userpage" />
+        <meta
+          property="og:image"
+          content="https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=1200&h=630&q=80"
+        />
+        <meta name="twitter:title" content="User Dashboard | DevDisplay" />
+        <meta
+          name="twitter:description"
+          content="Manage your DevDisplay profile and account settings."
+        />
+        <meta
+          name="twitter:image"
+          content="https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=1200&h=630&q=80"
+        />
+        <meta name="twitter:card" content="summary_large_image" />
+      </Helmet>
       <NavBar />
       <div className="user-page-wrapper">
         <div className="user-page-container">

--- a/src/components/pages/Youtube.jsx
+++ b/src/components/pages/Youtube.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useState, useEffect, useCallback } from "react";
+import { Helmet } from "react-helmet";
 import "../../css/pages/Youtube.css";
 import NavBar from "../modules/NavBar";
 import Footer from "../modules/Footer";
@@ -58,6 +59,30 @@ function Youtube() {
 
   return (
     <>
+      <Helmet>
+        <title>YouTube Search | DevDisplay</title>
+        <meta property="og:title" content="YouTube Search | DevDisplay" />
+        <meta
+          property="og:description"
+          content="Find and watch YouTube videos directly through DevDisplay's search interface."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://devdisplay.online/youtube" />
+        <meta
+          property="og:image"
+          content="https://images.unsplash.com/photo-1512028180093-07fb88f63dc1?auto=format&fit=crop&w=1200&h=630&q=80"
+        />
+        <meta name="twitter:title" content="YouTube Search | DevDisplay" />
+        <meta
+          name="twitter:description"
+          content="Find and watch YouTube videos directly through DevDisplay's search interface."
+        />
+        <meta
+          name="twitter:image"
+          content="https://images.unsplash.com/photo-1512028180093-07fb88f63dc1?auto=format&fit=crop&w=1200&h=630&q=80"
+        />
+        <meta name="twitter:card" content="summary_large_image" />
+      </Helmet>
       <NavBar />
       <div className="youtube-wrapper">
         <div className="youtube-container">


### PR DESCRIPTION
## Summary
- install `react-helmet` and use it for metadata management
- add Open Graph and Twitter card tags with unique titles, descriptions, URLs, and preview images across all pages

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3e62b14e48327acf3e6acdf4d3248

## Summary by Sourcery

Add react-helmet to manage and inject page-specific Open Graph and Twitter card metadata, including titles, descriptions, URLs, and preview images for all site pages

New Features:
- Integrate react-helmet for dynamic head metadata management

Enhancements:
- Add unique og:title, og:description, og:url, og:image and corresponding Twitter metadata to each page component

Build:
- Install react-helmet dependency