### PR TITLE
Point Vite API URL to Azure secret

### DIFF
--- a/.github/workflows/azure-static-web-apps-witty-sand-0aef9a403.yml
+++ b/.github/workflows/azure-static-web-apps-witty-sand-0aef9a403.yml
@@ -14,6 +14,8 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
+    env:
+      VITE_API_URL: ${{ secrets.AZURE_API_URL }}
     permissions:
        id-token: write
        contents: read


### PR DESCRIPTION
## Summary
- update the workflow environment so VITE_API_URL reads from the AZURE_API_URL secret

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68dd0fe8bbcc8327ab8ad6d0c09ee924

## Summary by Sourcery

CI:
- Configure VITE_API_URL environment variable to use AZURE_API_URL secret in GitHub Actions workflow