### PR TITLE
Create env production file in Azure workflow

### DIFF
--- a/.github/workflows/azure-static-web-apps-witty-sand-0aef9a403.yml
+++ b/.github/workflows/azure-static-web-apps-witty-sand-0aef9a403.yml
@@ -14,6 +14,8 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
+    env:
+      VITE_API_URL: ${{ secrets.AZURE_API_URL }}
     permissions:
        id-token: write
        contents: read
@@ -22,6 +24,18 @@ jobs:
         with:
           submodules: true
           lfs: false
+      - name: Create .env.production file
+        run: |
+          cat <<EOF > .env.production
+          VITE_API_URL=${{ secrets.AZURE_API_URL }}
+          VITE_RAPIDAPI_KEY=${{ secrets.VITE_RAPIDAPI_KEY }}
+          VITE_UNSPLASH_ACCESS_KEY=${{ secrets.VITE_UNSPLASH_ACCESS_KEY }}
+          VITE_YOUTUBE_API_KEY=${{ secrets.VITE_YOUTUBE_API_KEY }}
+          VITE_WEATHER_API_KEY=${{ secrets.VITE_WEATHER_API_KEY }}
+          VITE_EMAILJS_SERVICE_ID=${{ secrets.EMAILJS_SERVICE_ID }}
+          VITE_EMAILJS_TEMPLATE_ID=${{ secrets.EMAILJS_TEMPLATE_ID }}
+          VITE_EMAILJS_PUBLIC_KEY=${{ secrets.EMAILJS_PUBLIC_KEY }}
+          EOF
       - name: Install OIDC Client from Core Package
         run: npm install @actions/core@1.6.0 @actions/http-client
       - name: Get Id Token


### PR DESCRIPTION
## Summary
- update the workflow environment so VITE_API_URL reads from the AZURE_API_URL secret
- generate a .env.production file during the Azure workflow using the required GitHub secrets

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68dd0fe8bbcc8327ab8ad6d0c09ee924

## Summary by Sourcery

Update Azure Static Web Apps workflow to set VITE_API_URL from secrets and generate a .env.production file using GitHub secrets

CI:
- Add VITE_API_URL environment variable sourced from AZURE_API_URL secret
- Add step to generate .env.production file with required VITE_* and EMAILJS_* secrets