### PR TITLE
Load art page feature models from local assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,11 @@ Currently, two official plugins are available:
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
 
 You can access the api swagger site on https://devdisplay.online/swagger/index.html
+
+## 3D Art Page Model Hosting
+
+Place any `.glb` assets you want to feature on the `/art` page in `src/assets/art/3dmodels`.
+
+- The viewer automatically discovers files in that folder at build time via Vite's `import.meta.glob`.
+- If more than one model exists, a dropdown lets you choose which one to preview.
+- The download button links directly to the bundled asset so visitors can save the currently previewed file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
+        "@google/model-viewer": "^4.1.0",
         "axios": "^1.7.2",
         "bootstrap": "^5.3.2",
         "emailjs-com": "^3.2.0",
@@ -2563,6 +2564,22 @@
         "react": ">=16.3"
       }
     },
+    "node_modules/@google/model-viewer": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@google/model-viewer/-/model-viewer-4.1.0.tgz",
+      "integrity": "sha512-7WB/jS6wfBfRl/tWhsUUvDMKFE1KlKME97coDLlZQfvJD0nCwjhES1lJ+k7wnmf7T3zMvCfn9mIjM/mgZapuig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@monogrid/gainmap-js": "^3.1.0",
+        "lit": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "three": "^0.172.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.13",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
@@ -2889,6 +2906,33 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.4.0.tgz",
+      "integrity": "sha512-ficsEARKnmmW5njugNYKipTm4SFnbik7CXtoencDZzmzo/dQ+2Q0bgkzJuoJP20Aj0F+izzJjOqsnkd6F/o1bw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.1.tgz",
+      "integrity": "sha512-N+dm5PAYdQ8e6UlywyyrgI2t++wFGXfHx+dSJ1oBrg6FAxUj40jId++EaRm80MKX5JnlH1sBsyZ5h0bcZKemCg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.4.0"
+      }
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.1.0.tgz",
+      "integrity": "sha512-Obb0/gEd/HReTlg8ttaYk+0m62gQJmCblMOjHSMHRrBP2zdfKMHLCRbh/6ex9fSUJMKdjjIEiohwkbGD3wj2Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -3695,6 +3739,12 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
     },
     "node_modules/@types/warning": {
@@ -6005,6 +6055,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -6305,6 +6361,12 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
       "license": "MIT"
     },
     "node_modules/is-regex": {
@@ -7056,6 +7118,46 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/lit": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.1.tgz",
+      "integrity": "sha512-Ksr/8L3PTapbdXJCk+EJVB78jDodUMaP54gD24W186zGRARvwrsPfS60wae/SSCTCNZVPd1chXqio1qHQmu4NA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.1.tgz",
+      "integrity": "sha512-WGAWRGzirAgyphK2urmYOV72tlvnxw7YfyLDgQ+OZnM9vQQBQnumQ7jUJe6unEzwGU3ahFOjuz1iz1jjrpCPuw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.4.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.1.tgz",
+      "integrity": "sha512-S9hbyDu/vs1qNrithiNyeyv64c9yqiW9l+DBgI18fL+MTvOtWoFR0FWiyq1TxaYef5wNlpEmzlXoBlZEO+WjoA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -7625,6 +7727,16 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
+      }
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -8619,6 +8731,13 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/three": {
+      "version": "0.172.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.172.0.tgz",
+      "integrity": "sha512-6HMgMlzU97MsV7D/tY8Va38b83kz8YJX+BefKjspMNAv0Vx6dxMogHOrnRl/sbMIs3BPUKijPqDqJ/+UwJbIow==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
+    "@google/model-viewer": "^4.1.0",
     "axios": "^1.7.2",
     "bootstrap": "^5.3.2",
     "emailjs-com": "^3.2.0",

--- a/src/components/pages/Art.jsx
+++ b/src/components/pages/Art.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { Helmet } from "react-helmet-async"
+import "@google/model-viewer";
 import NavBar from "../modules/NavBar";
 import Footer from "../modules/Footer";
 import ScrollIndicator from "../modules/ScrollIndicator";
@@ -17,6 +18,38 @@ import New_truck_base from "../../assets/art/New_truck_base.png";
 import Bicycle_assembly from "../../assets/art/Bicycle_assembly.png";
 import signatureImg from "../../assets/art/signature.png";
 import signatureRawRender from "../../assets/art/Tagv2.png";
+
+const featureModelModules = import.meta.glob(
+  "../../assets/art/3dmodels/*.glb",
+  {
+    eager: true,
+  }
+);
+
+const FEATURE_MODELS = Object.entries(featureModelModules)
+  .map(([path, mod]) => {
+    const url = typeof mod === "string" ? mod : mod?.default;
+
+    if (!url) {
+      return null;
+    }
+
+    const filename = path.split("/").pop() || "model.glb";
+    const label = filename
+      .replace(/\.glb$/i, "")
+      .replace(/[-_]+/g, " ")
+      .replace(/\b\w/g, (char) => char.toUpperCase());
+
+    return {
+      url,
+      filename,
+      label,
+    };
+  })
+  .filter(Boolean)
+  .sort((a, b) => a.filename.localeCompare(b.filename));
+
+const FEATURE_MODEL = FEATURE_MODELS[0] ?? null;
 
 // --- Manual list (works anywhere) ---
 const cadArtImages = [
@@ -73,9 +106,18 @@ const cadArtImages = [
 
 const Art = () => {
   const [modalImg, setModalImg] = useState(null);
+  const [activeModel, setActiveModel] = useState(FEATURE_MODEL);
 
   const openModal = (img) => setModalImg(img);
   const closeModal = () => setModalImg(null);
+
+  const handleModelChange = (event) => {
+    const nextModel = FEATURE_MODELS.find(
+      (model) => model.filename === event.target.value
+    );
+
+    setActiveModel(nextModel ?? null);
+  };
 
   return (
     <>
@@ -127,6 +169,57 @@ const Art = () => {
                 mechanical design experiment assemblies.
               </p>
             </header>
+
+            <section className="feature-model-section" aria-label="Featured 3D model preview">
+              {activeModel ? (
+                <>
+                  <model-viewer
+                    className="feature-model-viewer"
+                    src={activeModel.url}
+                    alt={`3D model preview of ${activeModel.label}`}
+                    camera-controls
+                    auto-rotate
+                    autoplay
+                    interaction-prompt="none"
+                    shadow-intensity="1"
+                    exposure="0.9"
+                  />
+                  <div className="feature-model-actions">
+                    {FEATURE_MODELS.length > 1 && (
+                      <label className="feature-model-select">
+                        <span className="sr-only">Choose a model</span>
+                        <select
+                          aria-label="Choose a featured model"
+                          value={activeModel.filename}
+                          onChange={handleModelChange}
+                        >
+                          {FEATURE_MODELS.map((model) => (
+                            <option key={model.filename} value={model.filename}>
+                              {model.label}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                    )}
+                    <a
+                      className="feature-model-download"
+                      href={activeModel.url}
+                      download={activeModel.filename}
+                    >
+                      Download GLB
+                    </a>
+                    <span className="feature-model-hosting">
+                      Files served from <code>src/assets/art/3dmodels</code>.
+                    </span>
+                  </div>
+                </>
+              ) : (
+                <p className="feature-model-empty">
+                  Add <code>.glb</code> files under <code>src/assets/art/3dmodels</code> to
+                  display them here.
+                </p>
+              )}
+            </section>
 
             {cadArtImages.length === 0 ? (
               <p className="art-empty">

--- a/src/css/pages/Art.css
+++ b/src/css/pages/Art.css
@@ -54,6 +54,121 @@
   margin-bottom: 0.5rem;
 }
 
+/* Featured 3D model */
+.feature-model-section {
+  margin: 0 auto 2.5rem;
+  max-width: min(680px, 92vw);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.feature-model-viewer {
+  width: 100%;
+  height: 420px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(255,255,255,0.15), rgba(255,255,255,0.05));
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  overflow: hidden;
+}
+
+.feature-model-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: #f5f5f5;
+  font-size: 0.95rem;
+}
+
+.feature-model-select {
+  position: relative;
+}
+
+.feature-model-select select {
+  appearance: none;
+  padding: 10px 32px 10px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  background: rgba(0, 0, 0, 0.25);
+  color: #f5f5f5;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.feature-model-select::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: 14px;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+  transform: translateY(-50%);
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 6px solid rgba(255, 255, 255, 0.8);
+}
+
+.feature-model-download {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
+  color: #0b0b0b;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.feature-model-download:hover,
+.feature-model-download:focus-visible {
+  background: rgba(255, 255, 255, 0.32);
+  transform: translateY(-1px);
+}
+
+.feature-model-hosting {
+  opacity: 0.8;
+}
+
+.feature-model-empty {
+  text-align: center;
+  color: #f5f5f5;
+  background: rgba(0, 0, 0, 0.35);
+  padding: 18px 22px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.feature-model-empty code,
+.feature-model-hosting code {
+  font-family: "Source Code Pro", "Fira Code", Menlo, Monaco, Consolas, "Courier New", monospace;
+  color: #ffeb9e;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 600px) {
+  .feature-model-viewer {
+    height: 320px;
+  }
+}
+
 /* Gallery grid */
 .cad-art-gallery {
   width: 100%;


### PR DESCRIPTION
## Summary
- discover `.glb` files under `src/assets/art/3dmodels` at build time and surface them in the art page viewer
- allow choosing between multiple local models, update download handling, and show a helpful empty state when none are present
- style the new viewer controls and document how to add locally hosted models

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0d3cfc09c832799955c4376df5396

## Summary by Sourcery

Enable local 3D model hosting and interactive preview on the Art page by discovering .glb assets at build time, adding viewer and download controls, styling the new UI, and updating documentation.

New Features:
- Automatically discover and surface local .glb 3D models on the art page at build time
- Provide a model-viewer with camera controls, auto-rotate, and a download link for the current model
- Allow switching between multiple locally hosted models via a dropdown control

Enhancements:
- Add styled viewer container, action bar, empty state messaging, and responsive sizing for the 3D model section
- Alphabetically sort discovered models and default to the first when loaded

Build:
- Add the @google/model-viewer dependency to support 3D model rendering

Documentation:
- Document how to place and host .glb assets under src/assets/art/3dmodels in the README